### PR TITLE
Fix background scrolling along messages

### DIFF
--- a/client/src/app/app.component.css
+++ b/client/src/app/app.component.css
@@ -12,7 +12,7 @@
 #chat::before {
   content: '';
   display: block;
-  position: absolute;
+  position: sticky;
   top: 0;
   left: 0;
   width: 100%;
@@ -30,7 +30,8 @@
 }
 
 table {
-  position: relative;
+  position: absolute;
+  top: 0;
   color: white;
   min-width: 100%;
 }


### PR DESCRIPTION
Position sticky on the chat background prevents scrolling but pushes the chat messages down.
Position absolute on the chat message table brings it back to the top